### PR TITLE
Add Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.13-slim
+WORKDIR /app
+COPY pyproject.toml uv.lock ./
+RUN pip install --no-cache-dir uv
+RUN uv pip install --system -r uv.lock
+COPY . .
+CMD ["uvicorn", "app.server.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.9'
+services:
+  api:
+    build: .
+    ports:
+      - "8000:8000"
+    command: uvicorn app.server.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- provide a Dockerfile that installs dependencies and starts `uvicorn`
- provide a `docker-compose.yml` for running the service
- use uv in the Dockerfile to install from `uv.lock`

## Testing
- `pytest -q`
- `pre-commit run --files Dockerfile docker-compose.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc07b056c832a85476c19d66bd963